### PR TITLE
toLowerCase() only the individual character

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,12 @@ export default function jssCamelCase() {
     rule.style = {}
     for (let prop in style) {
       const value = style[prop]
-      prop = prop.replace(regExp, '-$1').toLowerCase()
+      prop = prop.replace(regExp, replace)
       rule.style[prop] = value
     }
   }
+}
+
+function replace (c) {
+  return '-' + c.toLowerCase()
 }


### PR DESCRIPTION
This is somewhat significantly more performant since it only has to do a single pass over the string, and doesn't call `.toLowerCase()` at all if there are no uppercase characters: [jsperf](http://jsperf.com/tolowercase-string-vs-char)